### PR TITLE
feat: stage-2 domain, interfaces, in-mem repo + tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+	go test ./... -coverprofile=coverage.out
+	go tool cover -func=coverage.out | grep total | awk '{print $$3}'

--- a/internal/domain/url/id_generator.go
+++ b/internal/domain/url/id_generator.go
@@ -1,0 +1,6 @@
+package url
+
+// IDGenerator generates unique identifactors.
+type IDGenerator interface {
+	Generate() (string, error)
+}

--- a/internal/domain/url/model.go
+++ b/internal/domain/url/model.go
@@ -1,0 +1,12 @@
+package url
+
+import (
+	"time"
+)
+
+// URL — agregat-root of domain
+type URL struct {
+	ID        string
+	Original  string
+	CreatedAt time.Time
+}

--- a/internal/domain/url/repository.go
+++ b/internal/domain/url/repository.go
@@ -1,0 +1,7 @@
+package url
+
+// Repository defines only what domain needs
+type Repository interface {
+	Save(u URL) error
+	Find(id string) (URL, error)
+}

--- a/internal/infrastructure/memory/id_gen.go
+++ b/internal/infrastructure/memory/id_gen.go
@@ -1,0 +1,17 @@
+package memory
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+)
+
+type RandIDGen struct{}
+
+// Generate returns 8-chars URL-safe code.
+func (RandIDGen) Generate() (string, error) {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}

--- a/internal/infrastructure/memory/url_repo.go
+++ b/internal/infrastructure/memory/url_repo.go
@@ -1,0 +1,36 @@
+package memory
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/sharipovr/go-tinyurl/internal/domain/url"
+)
+
+var ErrNotFound = errors.New("url not found")
+
+type URLRepo struct {
+	mu   sync.RWMutex
+	data map[string]url.URL
+}
+
+func NewURLRepo() *URLRepo {
+	return &URLRepo{data: make(map[string]url.URL)}
+}
+
+func (r *URLRepo) Save(u url.URL) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.data[u.ID] = u
+	return nil
+}
+
+func (r *URLRepo) Find(id string) (url.URL, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	u, ok := r.data[id]
+	if !ok {
+		return url.URL{}, ErrNotFound
+	}
+	return u, nil
+}

--- a/internal/service/shortener.go
+++ b/internal/service/shortener.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"time"
+
+	"github.com/sharipovr/go-tinyurl/internal/domain/url"
+)
+
+type Shortener struct {
+	repo url.Repository
+	gen  url.IDGenerator
+}
+
+func NewShortener(r url.Repository, g url.IDGenerator) *Shortener {
+	return &Shortener{repo: r, gen: g}
+}
+
+// Create generates ID and saves new record.
+func (s *Shortener) Create(original string) (url.URL, error) {
+	id, err := s.gen.Generate()
+	if err != nil {
+		return url.URL{}, err
+	}
+
+	u := url.URL{
+		ID:        id,
+		Original:  original,
+		CreatedAt: time.Now().UTC(),
+	}
+	return u, s.repo.Save(u)
+}
+
+// Resolve searches original URL by code.
+func (s *Shortener) Resolve(id string) (url.URL, error) {
+	return s.repo.Find(id)
+}

--- a/internal/service/shortener_test.go
+++ b/internal/service/shortener_test.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/sharipovr/go-tinyurl/internal/infrastructure/memory"
+)
+
+func TestShortener_CreateAndResolve(t *testing.T) {
+	repo := memory.NewURLRepo()
+	gen := memory.RandIDGen{}
+	s := NewShortener(repo, gen)
+
+	orig := "https://example.com/long"
+	u, err := s.Create(orig)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if u.Original != orig {
+		t.Errorf("want %q, got %q", orig, u.Original)
+	}
+
+	got, err := s.Resolve(u.ID)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.ID != u.ID {
+		t.Errorf("resolve returned wrong URL")
+	}
+}


### PR DESCRIPTION
The Domain layer holds pure business objects (URL) and their contracts (Repository, IDGenerator).

The Application layer (Shortener Service) orchestrates use-cases by calling those interfaces—without knowing how they’re implemented.

The Infrastructure layer provides concrete adapters (pgRepository, RandIDGen) that satisfy the same interfaces.
This structure lets us swap databases or ID algorithms without touching core logic and keeps unit tests fast with an in-memory repo while we add PostgreSQL later.